### PR TITLE
Bugfix for issue #17

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -44,7 +44,7 @@ version = 7
 
 # The version as the user will see it. If blank, the version attribute will be
 # used here.
-prettyVersion = 4.1.1
+prettyVersion = 4.1.2
 
 # The min and max revision of Processing compatible with your library.
 # Note that these fields use the revision and not the version of Processing,
@@ -53,4 +53,4 @@ prettyVersion = 4.1.1
 # https://raw.githubusercontent.com/processing/processing/master/build/shared/revisions.txt
 # Only use maxRevision (or minRevision), when your library is known to
 # break in a later (or earlier) release. Otherwise, use the default value 0.
-minRevision = 246
+minRevision = 247

--- a/src/main/java/jto/processing/sketch/mapper/SketchMapper.java
+++ b/src/main/java/jto/processing/sketch/mapper/SketchMapper.java
@@ -246,6 +246,19 @@ public class SketchMapper {
                 // Creates one surface at center of screen
                 surfaceMapper.createQuadSurface(initialSurfaceResolution, parent.width / 2, parent.height / 2);
             }
+
+            // add sketches to surfaces, if not set
+            if ( surfaceMapper.getSketchList().size() > 0 ){
+                Sketch defaultSketch = surfaceMapper.getSketchList().get(0);
+
+                for (SuperSurface ss : surfaceMapper.getSurfaces()) {
+                    Sketch s = ss.getSketch();
+                    if ( s == null ){
+                        ss.setSketch(defaultSketch);
+                    }
+                }
+            }
+
             firstDraw = false;
         }
 
@@ -274,8 +287,13 @@ public class SketchMapper {
             programOptions.hide();
             // Render each surface to the GLOS using their textures
             for (SuperSurface ss : surfaceMapper.getSurfaces()) {
-                ss.getSketch().draw();
-                ss.render(parent.g, ss.getSketch().getPGraphics().get());
+                Sketch s = ss.getSketch();
+                if ( s != null ){
+                    s.draw();
+                    ss.render(parent.g, s.getPGraphics().get());
+                } else {
+                    PApplet.println("Sketch not set?");
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #17 
- Added logic for setting to 'default' sketch in first draw if sketch is not set to surface
- Added check (and log) in draw if sketch is still null (i.e. won't crash, but will complain)