### PR TITLE
Better Handling of ControlP5 dependency missing.

### DIFF
--- a/src/main/java/jto/processing/sketch/mapper/ControlP5MissingException.java
+++ b/src/main/java/jto/processing/sketch/mapper/ControlP5MissingException.java
@@ -1,0 +1,5 @@
+package jto.processing.sketch.mapper;
+
+public class ControlP5MissingException extends RuntimeException {
+    private static final long serialVersionUID = 4902744341957494805L;
+}

--- a/src/main/java/jto/processing/sketch/mapper/SketchMapper.java
+++ b/src/main/java/jto/processing/sketch/mapper/SketchMapper.java
@@ -53,6 +53,13 @@ public class SketchMapper {
      */
     public SketchMapper(final PApplet parent, final String filename) {
         try {
+            Thread.currentThread().getContextClassLoader().loadClass("controlP5.ControlP5");
+        } catch (ClassNotFoundException e) {
+            parent.println("SketchMapper requires the ControlP5 library to also be installed.");
+            parent.println("Please install ControlP5 version 2.2.6 via the Contribution Manager and import into this sketch.");
+            throw new ControlP5MissingException();
+        }
+        try {
             this.parent = parent;
 
             //register our handler methods in this object on our parent.


### PR DESCRIPTION
Now SketchMapper detects that controlP5 is missing on initialization and
indicates what the user should do to get it installed and imported in
the console.

Closes #15